### PR TITLE
Add Hex/Elixir version range parsing

### DIFF
--- a/lib/vers/parser.rb
+++ b/lib/vers/parser.rb
@@ -85,6 +85,8 @@ module Vers
         parse_maven_range(range_string)
       when "nuget"
         parse_nuget_range(range_string)
+      when "hex", "elixir"
+        parse_hex_range(range_string)
       when "deb", "debian"
         parse_debian_range(range_string)
       when "rpm"
@@ -453,6 +455,44 @@ module Vers
       else
         # Fall back to standard constraint parsing
         parse_constraints(range_string, 'nuget')
+      end
+    end
+
+    # Hex/Elixir range parsing
+    def parse_hex_range(range_string)
+      # Handle "or" disjunction first
+      if range_string.include?(" or ")
+        or_parts = range_string.split(" or ").map(&:strip)
+        ranges = or_parts.map { |part| parse_hex_single_range(part) }
+        return ranges.reduce { |acc, range| acc.union(range) }
+      end
+
+      parse_hex_single_range(range_string)
+    end
+
+    def parse_hex_single_range(range_string)
+      # Handle "and" conjunction
+      if range_string.include?(" and ")
+        and_parts = range_string.split(" and ").map(&:strip)
+        ranges = and_parts.map { |part| parse_hex_constraint(part) }
+        return ranges.reduce { |acc, range| acc.intersect(range) }
+      end
+
+      parse_hex_constraint(range_string)
+    end
+
+    def parse_hex_constraint(constraint_string)
+      if constraint_string.match(/^~>\s*(.+)$/)
+        parse_pessimistic_range(Regexp.last_match(1).strip)
+      else
+        # Normalize == to = for our internal constraint parsing
+        normalized = constraint_string.gsub("==", "=")
+        constraint = Constraint.parse(normalized.strip)
+        if constraint.exclusion?
+          VersionRange.unbounded.exclude(constraint.version)
+        else
+          VersionRange.new([constraint.to_interval])
+        end
       end
     end
 

--- a/lib/vers/version_range.rb
+++ b/lib/vers/version_range.rb
@@ -109,7 +109,7 @@ module Vers
       
       intervals.each do |interval|
         if interval.contains?(version)
-          if interval.min && version_compare(interval.min, version) < 0
+          if interval.min.nil? || version_compare(interval.min, version) < 0
             result_intervals << Interval.new(
               min: interval.min,
               max: version,
@@ -117,8 +117,8 @@ module Vers
               max_inclusive: false
             )
           end
-          
-          if interval.max && version_compare(version, interval.max) < 0
+
+          if interval.max.nil? || version_compare(version, interval.max) < 0
             result_intervals << Interval.new(
               min: version,
               max: interval.max,

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -433,4 +433,106 @@ class TestParser < Minitest::Test
     assert range.contains?("1.9.9")
     refute range.contains?("2.0.0")
   end
+
+  # Hex/Elixir tests
+
+  def test_parse_native_hex_pessimistic_patch
+    # ~> 1.2.3 := >= 1.2.3, < 1.3.0
+    range = @parser.parse_native("~> 1.2.3", "hex")
+    assert range.contains?("1.2.3")
+    assert range.contains?("1.2.9")
+    refute range.contains?("1.3.0")
+    refute range.contains?("1.2.2")
+  end
+
+  def test_parse_native_hex_pessimistic_minor
+    # ~> 2.0 := >= 2.0.0, < 3.0.0
+    range = @parser.parse_native("~> 2.0", "hex")
+    assert range.contains?("2.0.0")
+    assert range.contains?("2.9.9")
+    refute range.contains?("3.0.0")
+    refute range.contains?("1.9.9")
+  end
+
+  def test_parse_native_hex_pessimistic_minor_nonzero
+    # ~> 2.1 := >= 2.1.0, < 3.0.0
+    range = @parser.parse_native("~> 2.1", "hex")
+    assert range.contains?("2.1.0")
+    assert range.contains?("2.9.9")
+    refute range.contains?("3.0.0")
+    refute range.contains?("2.0.9")
+  end
+
+  def test_parse_native_hex_exact_match
+    range = @parser.parse_native("== 1.2.3", "hex")
+    assert range.contains?("1.2.3")
+    refute range.contains?("1.2.4")
+    refute range.contains?("1.2.2")
+  end
+
+  def test_parse_native_hex_comparison_operators
+    range = @parser.parse_native(">= 1.0.0", "hex")
+    assert range.contains?("1.0.0")
+    assert range.contains?("2.0.0")
+    refute range.contains?("0.9.0")
+
+    range = @parser.parse_native("> 1.0.0", "hex")
+    refute range.contains?("1.0.0")
+    assert range.contains?("1.0.1")
+
+    range = @parser.parse_native("<= 2.0.0", "hex")
+    assert range.contains?("2.0.0")
+    assert range.contains?("1.0.0")
+    refute range.contains?("2.0.1")
+
+    range = @parser.parse_native("< 2.0.0", "hex")
+    refute range.contains?("2.0.0")
+    assert range.contains?("1.9.9")
+  end
+
+  def test_parse_native_hex_not_equal
+    range = @parser.parse_native("!= 1.5.0", "hex")
+    assert range.contains?("1.4.0")
+    assert range.contains?("1.6.0")
+    refute range.contains?("1.5.0")
+  end
+
+  def test_parse_native_hex_and_conjunction
+    range = @parser.parse_native(">= 1.0.0 and < 2.0.0", "hex")
+    assert range.contains?("1.0.0")
+    assert range.contains?("1.5.0")
+    refute range.contains?("0.9.0")
+    refute range.contains?("2.0.0")
+  end
+
+  def test_parse_native_hex_or_disjunction
+    range = @parser.parse_native("~> 1.0 or ~> 2.0", "hex")
+    assert range.contains?("1.5.0")
+    assert range.contains?("2.5.0")
+    refute range.contains?("3.0.0")
+  end
+
+  def test_parse_native_hex_combined_and_or
+    # ~> 1.0 and != 1.5.0 means >= 1.0.0 and < 2.0.0 but not 1.5.0
+    range = @parser.parse_native("~> 1.0 and != 1.5.0", "hex")
+    assert range.contains?("1.0.0")
+    assert range.contains?("1.4.0")
+    assert range.contains?("1.6.0")
+    refute range.contains?("1.5.0")
+    refute range.contains?("2.0.0")
+  end
+
+  def test_parse_native_hex_elixir_scheme_alias
+    range = @parser.parse_native("~> 1.2.3", "elixir")
+    assert range.contains?("1.2.3")
+    assert range.contains?("1.2.9")
+    refute range.contains?("1.3.0")
+  end
+
+  def test_parse_vers_uri_hex
+    range = @parser.parse("vers:hex/>=1.0.0|<2.0.0")
+    assert range.contains?("1.5.0")
+    refute range.contains?("2.0.0")
+    refute range.contains?("0.9.0")
+  end
 end


### PR DESCRIPTION
Support native Elixir version syntax including the ~> operator, == for exact match, != exclusions, and/or connectors. Registered under both "hex" and "elixir" scheme names.

Also fixes VersionRange#exclude for unbounded intervals where nil min/max checks prevented creating the split halves.